### PR TITLE
added defrost force flag for processing 3rd grade dependent class files

### DIFF
--- a/javassist-maven-plugin-core/pom.xml
+++ b/javassist-maven-plugin-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>nl.topicus.plugins</groupId>
 		<artifactId>javassist-maven-plugin-parent</artifactId>
-		<version>2.2-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/javassist-maven-plugin/pom.xml
+++ b/javassist-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>nl.topicus.plugins</groupId>
 		<artifactId>javassist-maven-plugin-parent</artifactId>
-		<version>2.2-SNAPSHOT</version>
+		<version>2.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/javassist-maven-plugin/src/main/java/nl/topicus/plugins/maven/javassist/JavassistMojo.java
+++ b/javassist-maven-plugin/src/main/java/nl/topicus/plugins/maven/javassist/JavassistMojo.java
@@ -54,6 +54,9 @@ public class JavassistMojo extends AbstractMojo implements ILogger {
 	@Parameter(property = "exclusions")
 	private List<String> exclusions;
 
+	@Parameter(property = "forceDefrost")
+	private boolean forceDefrost;
+
 	@Parameter(property = "outputDirectory", defaultValue = "${project.build.outputDirectory}")
 	private String outputDirectory;
 
@@ -127,6 +130,11 @@ public class JavassistMojo extends AbstractMojo implements ILogger {
 
 	public void writeFile(CtClass candidateClass, String targetDirectory)
 			throws Exception {
+		if (forceDefrost) {
+			error("FORCE DEFROSTING "+candidateClass.getName());
+			candidateClass.defrost();
+			candidateClass.defrost();
+		}
 		candidateClass.getClassFile().compact();
 		candidateClass.rebuildClassFile();
 
@@ -212,7 +220,7 @@ public class JavassistMojo extends AbstractMojo implements ILogger {
 	}
 
 	private void loadClassPath(final ClassLoader contextClassLoader,
-			final List<URL> urls) {
+							   final List<URL> urls) {
 		if (urls.size() <= 0)
 			return;
 
@@ -231,7 +239,7 @@ public class JavassistMojo extends AbstractMojo implements ILogger {
 
 	@Override
 	public void addMessage(File file, int line, int pos, String message,
-			Throwable e) {
+						   Throwable e) {
 		buildContext.addMessage(file, line, pos, message,
 				BuildContext.SEVERITY_ERROR, e);
 	}


### PR DESCRIPTION
I have a project which fails when processing jar'ed files. This is crucial to me since I need to modify a 3rd party lib (annotation enrichment). Please, could you pull the changes and deploy it on central? 
Regards,
Marcus